### PR TITLE
TVM CLI to compile models and generate config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,15 @@ they want to be able to refer to the model, and know that that reference will
 continue to refer to the same model. Creating a new folder and deprecating the
 old one is preferred over modifying existing models.
 
-### Additional Metadata
+## TVM CLI
 
-If you feel there are other information that would be relevant to other users,
-please add a README.md to the root of the model's folder. You can share in the
-document:
+[TVM](https://github.com/apache/incubator-tvm) is a machine learning compiler
+framework that compiles neutral network models to be executed on different
+hardware back-ends. TVM enables models specified in a wide range of ML
+frameworks to be run on a wide range of hardware devices.
 
-1. Link and description of any script for training
-1. Verbose description of how the training data is obtained and pre-processed
-1. Verbose discussion of bias and limitation in the training data
-1. Guide on how to do transfer learning using this model
-1. Share performance metrics on inference hardware
-1. Share accuracy metrics on well known datasets.
+In this model zoo, a CLI tool has been provided to compile models using TVM.
+This forms part of the validation workflow of the zoo as well as model
+deployment workflow for Autoware.
 
-Do commit any scripts or code you can share in the same folder as the models.
+See [TVM CLI documentation](scripts/tvm_cli/README.md) on how to use the tool.

--- a/scripts/tvm_cli/Dockerfile
+++ b/scripts/tvm_cli/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+
+COPY install_tvm.sh /tmp/install_tvm.sh
+RUN /tmp/install_tvm.sh
+
+RUN pip3 install --upgrade pip && pip3 install onnx tensorflow pyyaml jinja2 \
+    --use-feature=2020-resolver
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    python-opencv libopencv-dev build-essential && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/tmp
+WORKDIR /tmp
+COPY tvm_cli.py /tvm_cli/tvm_cli
+COPY templates /tvm_cli/templates
+ENV PATH="/tvm_cli:${PATH}"
+ENTRYPOINT [ "tvm_cli"]
+CMD ["-h"]

--- a/scripts/tvm_cli/README.md
+++ b/scripts/tvm_cli/README.md
@@ -1,0 +1,48 @@
+# TVM Command Line Interface
+
+A command line tool that compiles neural network models using
+[TVM](https://github.com/apache/incubator-tvm).
+
+## Usage
+
+Build a docker image that contains all the dependencies and scripts needed to
+run the tool.
+
+```bash
+$ # From root of the model zoo repo
+$ docker build -f scripts/tvm_cli/Dockerfile \
+               -t autoware-model-zoo/tvm_cli:local \
+               scripts/tvm_cli
+```
+
+The CLI can now be invoked as a container
+
+```bash
+$ docker run -it --rm -v `pwd`:`pwd` -w `pwd` \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    autoware-model-zoo/tvm_cli:local -h
+```
+
+To compile a model in the model zoo
+
+```bash
+$ export MODEL_DIR=<path to the folder containing definition.yaml>
+$ docker run \
+    -it --rm \
+    -v ${MODEL_DIR}:${MODEL_DIR} -w ${MODEL_DIR} \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    autoware-model-zoo/tvm_cli:local \
+        --config ${MODEL_DIR}/definition.yaml \
+        --output_path <output folder>
+```
+
+The output will consist of these file:
+
+- `deploy_lib.so` contains compiled operators required by the network to be used
+  with the TVM runtime
+- `deploy_param.params` contains trained weights for the network to be used with
+  the TVM runtime
+- `deploy_graph.json` contains the compute graph defining relationship between
+  the operators to be used with the TVM runtime
+- `inference_engine_tvm_config.hpp` contains declaration of a structure with
+  configuration for the TVM runtime C++ API.

--- a/scripts/tvm_cli/install_tvm.sh
+++ b/scripts/tvm_cli/install_tvm.sh
@@ -1,0 +1,94 @@
+#! /usr/bin/env bash
+# Copyright 2020 Autoware Foundation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+TVM_VERSION_TAG="v0.6.1"
+TVM_BASE_DIR="/tmp/tvm"
+TVM_BUILD_DIR="${TVM_BASE_DIR}/build"
+TVM_BUILD_CONFIG="${TVM_BUILD_DIR}/config.cmake"
+DLPACK_BASE_DIR="${TVM_BASE_DIR}/3rdparty/dlpack"
+DLPACK_BUILD_DIR="${DLPACK_BASE_DIR}/build"
+DLPACKCPP_HEADER_DIR="${DLPACK_BASE_DIR}/contrib/dlpack"
+DLPACKCPP_INSTALL_DIR="/usr/local/include/"
+
+# install dependencies
+apt-get update
+apt-get install -y --no-install-recommends \
+        ca-certificates ninja-build git python \
+        cmake libopenblas-dev g++ llvm-8 llvm-8-dev clang-9 \
+        python3.6 python3.6-dev python3-setuptools python3-pip antlr4
+
+# link clang-9 to be the default clang
+update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
+
+# install cross-compile toolchain
+if [ "$(uname -i)" != "aarch64" ]; then
+  apt-get install -y --no-install-recommends \
+    g++-aarch64-linux-gnu \
+    gcc-aarch64-linux-gnu
+fi
+
+rm -rf /var/lib/apt/lists/*
+python3 -m pip install --upgrade pip
+pip3 install mypy orderedset "antlr4-python3-runtime>=4.7,<4.8"
+
+# clone tvm and create build directory
+git clone --branch ${TVM_VERSION_TAG} --recursive \
+    https://github.com/apache/incubator-tvm ${TVM_BASE_DIR}
+mkdir -p ${TVM_BUILD_DIR}
+
+# copy a default configuration file
+cp ${TVM_BASE_DIR}/cmake/config.cmake ${TVM_BUILD_DIR}
+
+# turn on features
+echo "set(INSTALL_DEV TRUE)" >> ${TVM_BUILD_CONFIG}
+echo "set(USE_LLVM llvm-config-8)" >> ${TVM_BUILD_CONFIG}
+echo "set(USE_SORT ON)" >> ${TVM_BUILD_CONFIG}
+echo "set(USE_GRAPH_RUNTIME ON)" >> ${TVM_BUILD_CONFIG}
+echo "set(USE_BLAS openblas)" >> ${TVM_BUILD_CONFIG}
+if [[ -d "/usr/local/cuda" ]]; then
+    echo "set(USE_CUDA ON)" >> ${TVM_BUILD_CONFIG}
+fi
+
+# build and install tvm
+pushd ${TVM_BUILD_DIR}
+cmake ${TVM_BASE_DIR} -G Ninja
+ninja
+ninja install
+popd
+
+# install python extensions
+pushd ${TVM_BASE_DIR}/python
+python3 setup.py install
+popd
+
+pushd ${TVM_BASE_DIR}/topi/python
+python3 setup.py install
+popd
+
+# install dlpack headers
+mkdir -p ${DLPACK_BUILD_DIR}
+pushd ${DLPACK_BUILD_DIR}
+cmake ${DLPACK_BASE_DIR} -G Ninja
+ninja
+ninja install
+popd
+
+# install dlpackcpp headers
+cp -r ${DLPACKCPP_HEADER_DIR} ${DLPACKCPP_INSTALL_DIR}
+
+# clean up
+rm -rf ${TVM_BASE_DIR}

--- a/scripts/tvm_cli/templates/inference_engine_tvm_config.hpp.jinja2
+++ b/scripts/tvm_cli/templates/inference_engine_tvm_config.hpp.jinja2
@@ -1,0 +1,35 @@
+{%- set namespace = ["model_zoo"] + namespace.split('/') -%}
+#include "tvm_utility/pipeline.hpp"
+
+#pragma once
+{% for ns in namespace %}
+namespace {{ ns }} {
+{%- endfor %}
+
+tvm_utility::pipeline::InferenceEngineTVMConfig config {
+  .network_module_path = "{{ network_module_path }}",
+  .network_graph_path = "{{ network_graph_path }}",
+  .network_params_path = "{{ network_params_path }}",
+
+  .tvm_dtype_code = {{ tvm_dtype_code }},
+  .tvm_dtype_bits = {{ tvm_dtype_bits }},
+  .tvm_dtype_lanes = {{ tvm_dtype_lanes }},
+
+  .tvm_device_type = {{ tvm_device_type }},
+  .tvm_device_id = {{ tvm_device_id }},
+
+  .network_inputs = {
+  {%- for node in input_list %}
+    { "{{ node['name'] }}", { {{ node['shape']|join(', ') }} } }{{ ',' if not loop.last }}
+  {%- endfor %}
+  },
+
+  .network_outputs = {
+  {%- for node in output_list %}
+    { "{{ node['name'] }}", { {{ node['shape']|join(', ') }} } }{{ ',' if not loop.last }}
+  {%- endfor %}
+  }
+};
+{% for ns in namespace|reverse %}
+} // namespace {{ ns }}
+{%- endfor %}

--- a/scripts/tvm_cli/tvm_cli.py
+++ b/scripts/tvm_cli/tvm_cli.py
@@ -1,0 +1,221 @@
+#! /usr/bin/env python3
+#
+# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os
+import sys
+import onnx
+import yaml
+import tensorflow as tf
+import tvm.relay.testing.tf as tf_testing
+import tvm.relay as relay
+from jinja2 import Environment, FileSystemLoader
+from tvm.contrib import cc
+from os import path
+
+OUTPUT_NETWORK_MODULE_FILENAME = "deploy_lib.so"
+OUTPUT_NETWORK_GRAPH_FILENAME = "deploy_graph.json"
+OUTPUT_NETWORK_PARAM_FILENAME = "deploy_param.params"
+OUTPUT_CONFIG_FILENAME = "inference_engine_tvm_config.hpp"
+
+# This function checks the command-line arguments
+# and reads the necessary info from the .yaml file.
+def preprocess(args):
+    # 'info' is the output dictionary
+    info = {}
+
+    info['model_path'] = args.model
+    info['lanes'] = args.lanes
+    info['device_type'] = args.device_type
+    info['device_id'] = args.device_id
+    info['cross_compile'] = args.cross_compile
+
+    # .yaml file processing
+    with open(args.config, 'r') as yml_file:
+        yaml_dict = yaml.safe_load(yml_file)
+        # Get path of model file
+        if not info['model_path']:
+            info['model_path'] = yaml_dict['network']['filename']
+        if not info['model_path'].startswith('/'):
+            yaml_file_dir = path.dirname(yml_file.name)
+            info['model_path'] = path.join(yaml_file_dir, info['model_path'])
+        # Get list of input names and shapes from .yaml file
+        info['input_list'] = yaml_dict['network_parameters']['input_nodes']
+        info['input_dict'] = {}                     # Used to compile the model
+        for input_elem in info['input_list']:
+            info['input_dict'][str(input_elem['name'])] = input_elem['shape']
+        # Get input data type
+        input_data_type = yaml_dict['network_parameters']['datatype']
+        if input_data_type == 'float32':
+            info['dtype_code'] = 'kDLFloat'
+            info['dtype_bits'] = 32
+        elif input_data_type == 'int8':
+            info['dtype_code'] = 'kDLInt'
+            info['dtype_bits'] = 8
+        else:
+            raise Exception('Specified input data type not supported')
+        # Get list of output names and shapes from .yaml file
+        info['output_list'] = yaml_dict['network_parameters']['output_nodes']
+        info['output_names'] = []                   # Used to compile the model
+        for output_elem in info['output_list']:
+            info['output_names'].append(str(output_elem['name']))
+
+    # Define the root directory and check if the specified output_path exists.
+    # If not the corresponding directories are created.
+    # Note: if output_path has not been specified by the user,
+    # default to the 'filename' field from the .yaml file
+    if args.output_path:
+        info['output_path'] = args.output_path
+    if not path.isdir(info['output_path']):
+        os.makedirs(info['output_path'])
+
+    # starting from the config file directory, take 4 levels of parent directory
+    # as the namespace in the case of the model zoo these 4 levels correspond to
+    # <task area>/<autonomous driving task>/<model name>/<model variant name>.
+    model_dir = path.abspath(path.dirname(args.config))
+    namespaces = model_dir.split(path.sep)
+    if len(namespaces) < 4:
+        info['namespace'] = model_dir
+    else:
+        info['namespace'] = path.sep.join(namespaces[-4:])
+
+    return info
+
+# This function generates the config .hpp file.
+def generate_config_file(info):
+    # Setup jinja template and write the config file
+    root = path.dirname(path.abspath(__file__))
+    templates_dir = path.join(root, 'templates')
+    env = Environment( loader = FileSystemLoader(templates_dir),
+                       keep_trailing_newline = True )
+    template = env.get_template(OUTPUT_CONFIG_FILENAME + ".jinja2")
+    filename = path.join(info['output_path'], OUTPUT_CONFIG_FILENAME)
+
+    print('Writing pipeline configuration to', filename)
+    with open(filename, 'w') as fh:
+        fh.write(template.render(
+            namespace = info['namespace'],
+            network_module_path = path.join('.', OUTPUT_NETWORK_MODULE_FILENAME),
+            network_graph_path = path.join('.', OUTPUT_NETWORK_GRAPH_FILENAME),
+            network_params_path = path.join('.', OUTPUT_NETWORK_PARAM_FILENAME),
+            tvm_dtype_code = info['dtype_code'],
+            tvm_dtype_bits = info['dtype_bits'],
+            tvm_dtype_lanes = info['lanes'],
+            tvm_device_type = info['device_type'],
+            tvm_device_id = info['device_id'],
+            input_list = info['input_list'],
+            output_list = info['output_list']
+        ))
+
+# This functions compiles the model.
+def compile(info):
+    if info['model_path'].endswith('.onnx'):
+        is_onnx = True
+    elif info['model_path'].endswith('.pb'):
+        is_onnx = False
+    else:
+        raise Exception('Model file format not supported')
+
+    # Load model
+    if is_onnx:
+        onnx_model = onnx.load(info['model_path'])
+        mod, params = relay.frontend.from_onnx(onnx_model, info['input_dict'])
+        optimization_level = 3
+    else:
+        with tf.compat.v1.Session() as sess:
+            with tf.io.gfile.GFile(info['model_path'], 'rb') as f:
+                graph_def = tf.compat.v1.GraphDef()
+                graph_def.ParseFromString(f.read())
+                tf.import_graph_def(graph_def, name='')
+                graph_def = sess.graph.as_graph_def()
+                graph_def = tf_testing.ProcessGraphDefParam(graph_def)
+
+        input_shape_dict = {'DecodeJpeg/contents': info['input_list']}
+        mod, params = relay.frontend.from_tensorflow(graph_def,
+                                                shape=input_shape_dict,
+                                                outputs=info['output_names'])
+        optimization_level = 2
+
+    # Set compilation params
+    target = 'llvm'
+    if info['cross_compile']:
+        target += ' -target=aarch64-linux-gnu'
+
+    # Compile model
+    # Note opt_level cannot be higher than 2 because of a bug:
+    # https://discuss.tvm.ai/t/tvm-0-6-1-compile-yolo-v2-tiny-fail-worked-in-v0-5-2/7244
+    with relay.build_config(opt_level=optimization_level):
+        graph, lib, params = relay.build(mod,
+                                         target=target,
+                                         params=params)
+
+    # Write the compiled model to files
+    output_model_path = path.join(info['output_path'],
+                                  OUTPUT_NETWORK_MODULE_FILENAME)
+    output_graph_path = path.join(info['output_path'],
+                                  OUTPUT_NETWORK_GRAPH_FILENAME)
+    output_param_path = path.join(info['output_path'],
+                                  OUTPUT_NETWORK_PARAM_FILENAME)
+
+    print('Writing library to', output_model_path)
+    if info['cross_compile']:
+        lib.export_library(output_model_path,
+                           cc.build_create_shared_func(
+                               options=['--target=aarch64-linux-gnu',
+                                        '-march=armv8-a',
+                                        '-mfpu=NEON'],
+                               compile_cmd='/usr/bin/clang'))
+    else:
+        lib.export_library(output_model_path)
+
+    print('Writing graph to', output_graph_path)
+    with open(output_graph_path, 'w') as graph_file:
+        graph_file.write(graph)
+
+    print('Writing weights to', output_param_path)
+    with open(output_param_path, 'wb') as param_file:
+        param_file.write(relay.save_param_dict(params))
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Compile model and configuration file (TVM)')
+    requiredNamed = parser.add_argument_group('required arguments')
+    requiredNamed.add_argument('--config',
+                               help='Path to .yaml config file (input)',
+                               required=True)
+    requiredNamed.add_argument('--output_path',
+                               help='Path where network module, '
+                                    'network graph and network parameters '
+                                    'will be stored',
+                               required=True)
+    parser.add_argument('--model',
+                        help='Path to .onnx/.pb model file (input)')
+    parser.add_argument('--device_type',
+                        help='User-specified device type',
+                        choices=['kDLCPU', 'kDLGPU', 'kDLCPUPinned',
+                                 'kDLOpenCL', 'kDLVulkan', 'kDLMetal',
+                                 'kDLVPI', 'kDLROCM', 'kDLExtDev'],
+                        default='kDLCPU')
+    parser.add_argument('--device_id',
+                        help='User-specified device ID',
+                        type=int,
+                        default=1)
+    parser.add_argument('--lanes',
+                        help='Number of lanes, default value is 1',
+                        type=int,
+                        default=1)
+    parser.add_argument('--cross_compile',
+                        help='Set to cross compile for ArmV8a with NEON',
+                        action='store_true',
+                        default=False)
+
+    # The dictionary 'info' contains all the information provided by the user
+    # and the information found in the .yaml file.
+    info = preprocess(parser.parse_args())
+    compile(info)
+    generate_config_file(info)


### PR DESCRIPTION
Python script to compile a model using TVM and generate a C++ header
file to be used in the inference engine. Support .onnx/.pb models.
The tool takes the model zoo definition.yaml file as an input

A dockerfile is provided to build an environment with all required
dependencies to run the cli tool and build the example pipeline for
yolo_v2_tiny. The upstream TVM docker images are not maintained very
well; hence we manually build and install tvm to be able to use a newer
version and more reproducible environment.

Change-Id: Ie74f9aef4ebacd8a9f446ea88f6e8443be6238ec
Signed-off-by: Luca Foschiani <luca.foschiani@arm.com>
Issue-Id: SCM-874