### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ support. To clone the zoo:
 
 ```sh
 $ GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/autowarefoundation/modelzoo.git
+$ cd modelzoo
 $ git lfs install
 $ git lfs pull
 ```

--- a/perception/camera_obstacle_detection/yolo_v2_tiny/tensorflow_fp32_coco/README.md
+++ b/perception/camera_obstacle_detection/yolo_v2_tiny/tensorflow_fp32_coco/README.md
@@ -14,9 +14,7 @@ was used to produce the final model file.
 
 ## Compile and run the example pipeline
 
-All commands should be run from the root of the model zoo directory. First,
-build the TVM docker image by following instructions in the TVM CLI
-[documentation](../../../../scripts/tvm_cli/README.md).
+All commands should be run from the root of the model zoo directory.
 
 Compile the model by running the TVM CLI script in a docker container.
 
@@ -27,7 +25,7 @@ $ docker run \
     -it --rm \
     -v ${MODEL_DIR}:${MODEL_DIR} -w ${MODEL_DIR} \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    autoware-model-zoo/tvm_cli:local \
+    autoware/model-zoo-tvm-cli:latest \
         --config ${MODEL_DIR}/definition.yaml \
         --output_path ${MODEL_DIR}/example_pipeline/build
 ```
@@ -40,7 +38,7 @@ $ docker run \
     -v ${MODEL_DIR}:${MODEL_DIR} -w ${MODEL_DIR}/example_pipeline/build \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     --entrypoint "" \
-    autoware-model-zoo/tvm_cli:local \
+    autoware/model-zoo-tvm-cli:latest \
     bash -c "cmake .. && make -j"
 ```
 
@@ -67,6 +65,9 @@ $ docker run \
     -v ${MODEL_DIR}:${MODEL_DIR} \
     -w ${MODEL_DIR}/example_pipeline/build \
     --entrypoint "" \
-    autoware-model-zoo/tvm_cli:local \
+    autoware/model-zoo-tvm-cli:latest \
         ./example_pipeline
 ```
+
+For more information about getting the TVM docker image, see the TVM CLI
+[documentation](../../../../scripts/tvm_cli/README.md).

--- a/scripts/tvm_cli/README.md
+++ b/scripts/tvm_cli/README.md
@@ -5,14 +5,12 @@ A command line tool that compiles neural network models using
 
 ## Usage
 
-Build a docker image that contains all the dependencies and scripts needed to
-run the tool.
+Pull a docker image that contains all the dependencies and scripts needed to run
+the tool. Alternatively, the image can be built locally, see the
+[Building the docker image](#building-the-docker-image) paragraph.
 
 ```bash
-$ # From root of the model zoo repo
-$ docker build -f scripts/tvm_cli/Dockerfile \
-               -t autoware-model-zoo/tvm_cli:local \
-               scripts/tvm_cli
+$ docker pull autoware/model-zoo-tvm-cli
 ```
 
 The CLI can now be invoked as a container
@@ -20,7 +18,7 @@ The CLI can now be invoked as a container
 ```bash
 $ docker run -it --rm -v `pwd`:`pwd` -w `pwd` \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    autoware-model-zoo/tvm_cli:local -h
+    autoware/model-zoo-tvm-cli:latest -h
 ```
 
 To compile a model in the model zoo
@@ -31,7 +29,7 @@ $ docker run \
     -it --rm \
     -v ${MODEL_DIR}:${MODEL_DIR} -w ${MODEL_DIR} \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    autoware-model-zoo/tvm_cli:local \
+    autoware/model-zoo-tvm-cli:latest \
         --config ${MODEL_DIR}/definition.yaml \
         --output_path <output folder>
 ```
@@ -46,3 +44,16 @@ The output will consist of these file:
   the operators to be used with the TVM runtime
 - `inference_engine_tvm_config.hpp` contains declaration of a structure with
   configuration for the TVM runtime C++ API.
+
+### Building the docker image
+
+Instead of pulling the docker image, it can be built locally.
+
+```bash
+$ # From root of the model zoo repo
+$ docker build -f scripts/tvm_cli/Dockerfile \
+               -t autoware/model-zoo-tvm-cli:local \
+               scripts/tvm_cli
+```
+
+The previous commands are then used with `:local` instead of `:latest`.


### PR DESCRIPTION
Change the instructions to use the docker hub image instead of building
it locally. Keep the building instructions as an alternative.