### PR TITLE
Dockerfile for aarch64 tvm cli docker

### DIFF
--- a/scripts/tvm_cli/Dockerfile
+++ b/scripts/tvm_cli/Dockerfile
@@ -1,13 +1,5 @@
-FROM ubuntu:18.04
-
-COPY install_tvm.sh /tmp/install_tvm.sh
-RUN /tmp/install_tvm.sh
-
-RUN pip3 install --upgrade pip && pip3 install onnx tensorflow pyyaml jinja2 \
-    pytest --use-feature=2020-resolver
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends \
-    python-opencv libopencv-dev build-essential && rm -rf /var/lib/apt/lists/*
+ARG FROM_ARG
+FROM $FROM_ARG
 
 ENV HOME=/tmp
 WORKDIR /tmp

--- a/scripts/tvm_cli/Dockerfile.dependencies.amd64
+++ b/scripts/tvm_cli/Dockerfile.dependencies.amd64
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+ARG FROM_ARG
+FROM $FROM_ARG
 
 COPY install_tvm.sh /tmp/install_tvm.sh
 RUN /tmp/install_tvm.sh
@@ -8,11 +9,3 @@ RUN pip3 install --upgrade pip && pip3 install onnx tensorflow pyyaml jinja2 \
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
     python-opencv libopencv-dev build-essential && rm -rf /var/lib/apt/lists/*
-
-ENV HOME=/tmp
-WORKDIR /tmp
-COPY tvm_cli.py /tvm_cli/tvm_cli
-COPY templates /tvm_cli/templates
-ENV PATH="/tvm_cli:${PATH}"
-ENTRYPOINT [ "tvm_cli"]
-CMD ["-h"]

--- a/scripts/tvm_cli/Dockerfile.dependencies.arm64
+++ b/scripts/tvm_cli/Dockerfile.dependencies.arm64
@@ -1,0 +1,48 @@
+ARG FROM_ARG
+FROM $FROM_ARG
+
+COPY install_tvm.sh /tmp/install_tvm.sh
+RUN /tmp/install_tvm.sh
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get -y install software-properties-common && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python-opencv libopencv-dev build-essential \
+        protobuf-compiler libprotobuf-dev libhdf5-dev wget gfortran-9 && \
+    rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
+    update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-9 1
+RUN pip3 install --upgrade pip setuptools && \
+    pip3 install --upgrade --use-feature=2020-resolver cython protobuf \
+        "numpy<1.19.0" wheel pyyaml jinja2 future pytest && \
+    pip3 install --upgrade --no-deps keras_preprocessing
+
+# build and install onnx
+RUN cd /tmp && \
+    git clone -b v1.7.0 https://github.com/onnx/onnx.git && \
+    cd onnx && \
+    git submodule update --init --recursive && \
+    python3 setup.py install && \
+    rm -rf /tmp/onnx
+
+# install bazel
+RUN cd /tmp && \
+    wget https://github.com/bazelbuild/bazel/releases/download/3.4.0/bazel-3.4.0-linux-arm64 && \
+    ln -s /tmp/bazel-3.4.0-linux-arm64 /usr/bin/bazel && \
+    chmod +x /tmp/bazel-3.4.0-linux-arm64 && /tmp/bazel-3.4.0-linux-arm64
+
+# build and install tensorflow
+RUN git clone --depth 1 -b v2.3.0 https://github.com/tensorflow/tensorflow.git \
+        /tmp/tensorflow && \
+    cd /tmp/tensorflow && \
+    yes "" | ./configure && \
+    bazel build --config=noaws --config=monolithic --local_cpu_resources=32 \
+        //tensorflow/tools/pip_package:build_pip_package && \
+    ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
+        /tmp/tensorflow_pkg && \
+    pip3 install \
+        /tmp/tensorflow_pkg/tensorflow-2.3.0-cp36-cp36m-linux_aarch64.whl && \
+    rm -rf /tmp/tensorflow /tmp/tensorflow_pkg ~/.cache

--- a/scripts/tvm_cli/README.md
+++ b/scripts/tvm_cli/README.md
@@ -8,8 +8,6 @@ A command line tool that compiles neural network models using
 In all the subsequent commands, if CUDA needs to be enabled, the docker image
 must be run with a flag which exposes the gpu, e.g. [--gpus 0] or [--gpus all].
 
-The CLI can now be invoked as a container
-
 ```bash
 $ docker run -it --rm -v `pwd`:`pwd` -w `pwd` \
     -u $(id -u ${USER}):$(id -g ${USER}) \
@@ -41,15 +39,13 @@ The output will consist of these file:
 - `inference_engine_tvm_config.hpp` contains declaration of a structure with
   configuration for the TVM runtime C++ API.
 
-# Validation script
+## Validation script
 
 A testing script is provided. The script automatically detects all the .yaml
 definition files in a user-specified path, executes the compilation of the
 model corresponding to each file, and checks the output afterwards. The test
 corresponding to a certain .yaml file is only executed if the 'enable_testing'
 field is set to true.
-
-## Usage
 
 The tests need to be run inside a container. The user is required to specify
 the folder containing the .yaml files using the -v option. This folder will be
@@ -66,32 +62,24 @@ $ docker run -it --rm \
 The output will contain information regarding which tests were successful and
 which weren't.
 
-# Obtaining/Building the docker image
-
-Pull a docker image that contains all the dependencies and scripts needed to
-run the tool. Alternatively, the image can be built locally.
-
-```bash
-$ docker pull autoware/model-zoo-tvm-cli
-```
+## Building the docker image
 
 Instead of pulling the docker image, it can be built locally.
 
 ```bash
 $ # From root of the model zoo repo
-$ docker build -f scripts/tvm_cli/Dockerfile \
-               -t autoware/model-zoo-tvm-cli:local \
-               scripts/tvm_cli
+$ ./scripts/tvm_cli/build.sh
+...
+Successfully built 547afbbfd193
+Successfully tagged autoware/model-zoo-tvm-cli:local
 ```
 
-If CUDA is needed, the appropriate Dockerfile needs to be used instead.
+The previous commands are then used with `:local` instead of `:latest`. If
+Nvidia drivers are installed on the system, CUDA will be enabled for TVM. The
+script also distinguish between an arm64 and an amd64 system to build the
+appropriate docker image.
 
-```bash
-$ # From root of the model zoo repo
-$ docker build -f scripts/tvm_cli/Dockerfile.cuda \
-               -t autoware/model-zoo-tvm-cli:local \
-               scripts/tvm_cli
-```
-
-If the image is built locally, all the command in the *Usage* sections must be
-run using `:local` instead of `:latest`.
+*Note:* If CUDA is needed, the image must be built locally on a machine with
+Nvidia drivers installed. In all the docker commands shown, if CUDA needs to be
+enabled, the docker image must be run with a flag which exposes the gpu, e.g.
+[--gpus 0] or [--gpus all].

--- a/scripts/tvm_cli/build.sh
+++ b/scripts/tvm_cli/build.sh
@@ -1,0 +1,90 @@
+#! /usr/bin/env bash
+# Copyright 2020 Autoware Foundation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+IMAGE_NAME="autoware/model-zoo-tvm-cli"
+TAG_NAME="local"
+
+function usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "    -h,--help              Display the usage and exit."
+    echo "    -i,--image-name <name> Set docker images name."
+    echo "                           Default: $IMAGE_NAME"
+    echo "    -t,--tag <tag>         Tag use for the docker images."
+    echo "                           Default: $TAG_NAME"
+    echo ""
+}
+
+OPTS=$(getopt --options hi:t: \
+         --long help,image-name:,tag: \
+         --name "$0" -- "$@")
+eval set -- "$OPTS"
+
+while true; do
+  case $1 in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -i|--image-name)
+      IMAGE_NAME="$2"
+      shift 2
+      ;;
+    -t|--tag)
+      TAG_NAME="$2"
+      shift 2
+      ;;
+    --)
+      if [ -n "$2" ];
+      then
+        echo "Invalid parameter: $2"
+        exit 1
+      fi
+      break
+      ;;
+    *)
+      echo "Invalid option"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+FROM_ARG="ubuntu:18.04"
+if [[ -d "/proc/driver/nvidia" ]]; then
+    FROM_ARG="nvidia/cuda:10.1-devel-ubuntu18.04"
+fi
+
+DOCKER_FILE="Dockerfile.dependencies.arm64"
+if [[ $(uname -a) == *"x86_64"* ]]; then
+    DOCKER_FILE="Dockerfile.dependencies.amd64"
+fi
+
+BASE_IMAGE_NAME="autoware/model-zoo-tvm-cli-base:local"
+BUILD_CONTEXT_DIR=${SCRIPT_PATH}
+
+# Build base image with all dependencies
+docker build -f "${SCRIPT_PATH}"/"${DOCKER_FILE}" \
+             --build-arg FROM_ARG="${FROM_ARG}" \
+             -t "${BASE_IMAGE_NAME}"\
+                "${BUILD_CONTEXT_DIR}"
+
+# Build final image with tvm_cli installed
+docker build -f "${SCRIPT_PATH}"/Dockerfile \
+             --build-arg FROM_ARG="${BASE_IMAGE_NAME}" \
+             --tag "${IMAGE_NAME}":"${TAG_NAME}" \
+                "${BUILD_CONTEXT_DIR}"

--- a/scripts/tvm_cli/tvm_cli.py
+++ b/scripts/tvm_cli/tvm_cli.py
@@ -9,7 +9,6 @@ import os
 import sys
 import onnx
 import yaml
-import tensorflow as tf
 import tvm.relay.testing.tf as tf_testing
 import tvm.relay as relay
 from jinja2 import Environment, FileSystemLoader
@@ -18,6 +17,7 @@ from tvm import autotvm
 import tvm
 from os import path
 import pytest
+import tensorflow as tf
 
 OUTPUT_NETWORK_MODULE_FILENAME = "deploy_lib.so"
 OUTPUT_NETWORK_GRAPH_FILENAME = "deploy_graph.json"


### PR DESCRIPTION
On Aarch64 ubuntu, onnx and tensorflow pre-compiled packages are not
provided. They need to be compiled from source.

The docker build is now split into 2 stages. The first stage is
different between amd64 and arm64. A script `build.sh` is provided
to orchestrate the build and hide this complexity from user.

Change-Id: If463859cb19761240ccaac0c2e19de4191017c1b
Issue-Id: SCM-1463
Signed-off-by: Liyou Zhou <liyou.zhou@arm.com>