### PR TITLE
Add cuda option to TVM cli docker build script

### DIFF
--- a/scripts/tvm_cli/README.md
+++ b/scripts/tvm_cli/README.md
@@ -64,7 +64,20 @@ which weren't.
 
 ## Building the docker image
 
-Instead of pulling the docker image, it can be built locally.
+Instead of pulling the docker image, it can be built locally using the
+`build.sh` script:
+
+```bash
+Usage: ./scripts/tvm_cli/build.sh [OPTIONS]
+    -c,--cuda              Build TVM cli with cuda enabled.
+    -h,--help              Display the usage and exit.
+    -i,--image-name <name> Set docker images name.
+                           Default: autoware/model-zoo-tvm-cli
+    -t,--tag <tag>         Tag use for the docker images.
+                           Default: local
+```
+
+Here an example to build the image with default parameters:
 
 ```bash
 $ # From root of the model zoo repo
@@ -79,7 +92,7 @@ Nvidia drivers are installed on the system, CUDA will be enabled for TVM. The
 script also distinguish between an arm64 and an amd64 system to build the
 appropriate docker image.
 
-*Note:* If CUDA is needed, the image must be built locally on a machine with
-Nvidia drivers installed. In all the docker commands shown, if CUDA needs to be
-enabled, the docker image must be run with a flag which exposes the gpu, e.g.
+*Note:* If CUDA is needed, the `build.sh` script must be invoked with the `-c`
+argument. In all the docker commands shown, if CUDA needs to be enabled, the
+docker image must be run with a flag which exposes the gpu, e.g.
 [--gpus 0] or [--gpus all].

--- a/scripts/tvm_cli/build.sh
+++ b/scripts/tvm_cli/build.sh
@@ -17,9 +17,11 @@ set -e
 
 IMAGE_NAME="autoware/model-zoo-tvm-cli"
 TAG_NAME="local"
+FROM_ARG="ubuntu:18.04"
 
 function usage() {
     echo "Usage: $0 [OPTIONS]"
+    echo "    -c,--cuda              Build TVM cli with cuda enabled."
     echo "    -h,--help              Display the usage and exit."
     echo "    -i,--image-name <name> Set docker images name."
     echo "                           Default: $IMAGE_NAME"
@@ -28,13 +30,17 @@ function usage() {
     echo ""
 }
 
-OPTS=$(getopt --options hi:t: \
-         --long help,image-name:,tag: \
+OPTS=$(getopt --options chi:t: \
+         --long cuda,help,image-name:,tag: \
          --name "$0" -- "$@")
 eval set -- "$OPTS"
 
 while true; do
   case $1 in
+    -c|--cuda)
+      FROM_ARG="nvidia/cuda:10.1-devel-ubuntu18.04"
+      shift 1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -63,11 +69,6 @@ while true; do
 done
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-
-FROM_ARG="ubuntu:18.04"
-if [[ -d "/proc/driver/nvidia" ]]; then
-    FROM_ARG="nvidia/cuda:10.1-devel-ubuntu18.04"
-fi
 
 DOCKER_FILE="Dockerfile.dependencies.arm64"
 if [[ $(uname -a) == *"x86_64"* ]]; then


### PR DESCRIPTION
Add option to build cuda enabled TVM cli docker images

Add -c option to the build.sh script to build the docker image
with cuda enabled.

Signed-off-by: Luca Fancellu <luca.fancellu@arm.com>
Change-Id: Idd513bb1418c91a5ffdcd80c292ac85151b69c28