### PR TITLE
Add CI jobs for docker image creation

### DIFF
--- a/.github/workflows/docker-pr.yaml
+++ b/.github/workflows/docker-pr.yaml
@@ -1,0 +1,62 @@
+name: Docker pull requests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/tvm_cli/**'
+
+jobs:
+
+  dockerfile-lint:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: hadolint/hadolint:latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Linting
+        run: |
+          hadolint scripts/tvm_cli/Dockerfile
+          hadolint scripts/tvm_cli/Dockerfile.dependencies.amd64
+          hadolint scripts/tvm_cli/Dockerfile.dependencies.arm64
+
+  build-docker:
+      needs: dockerfile-lint
+
+      runs-on: ubuntu-latest
+      env:
+        IMAGE_NAME: autoware/model-zoo-tvm-cli
+        TAG_NAME: local
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: amd64 image build
+          run: |
+            # Build image
+            ./scripts/tvm_cli/build.sh -i "$IMAGE_NAME" -t "$TAG_NAME"
+
+  build-docker-cuda:
+      needs: dockerfile-lint
+
+      runs-on: ubuntu-latest
+      env:
+        IMAGE_NAME: autoware/model-zoo-tvm-cli
+        TAG_NAME: local-cuda
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: amd64 image build with cuda
+          run: |
+            # Build image
+            ./scripts/tvm_cli/build.sh -c -i "$IMAGE_NAME" -t "$TAG_NAME"

--- a/.github/workflows/docker-push-master.yaml
+++ b/.github/workflows/docker-push-master.yaml
@@ -1,0 +1,60 @@
+name: Docker push on master
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'scripts/tvm_cli/**'
+
+jobs:
+
+  build-push-docker:
+
+      if: github.repository_owner == 'autowarefoundation'
+
+      runs-on: ubuntu-latest
+      env:
+        IMAGE_NAME: autoware/model-zoo-tvm-cli
+        TAG_NAME: bleedingedge
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: amd64 image build
+          run: |
+            docker login -u "${{ secrets.DKR_USR }}" -p "${{ secrets.DKR_PASS }}"
+            # Build image
+            ./scripts/tvm_cli/build.sh -i "$IMAGE_NAME" -t "$TAG_NAME"
+
+        - name: amd64 image push
+          run: |
+            # Push images to docker hub space
+            docker push $IMAGE_NAME:$TAG_NAME
+
+  build-push-docker-cuda:
+
+      if: github.repository_owner == 'autowarefoundation'
+
+      runs-on: ubuntu-latest
+      env:
+        IMAGE_NAME: autoware/model-zoo-tvm-cli
+        TAG_NAME: bleedingedge-cuda
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: amd64 image build with cuda
+          run: |
+            docker login -u "${{ secrets.DKR_USR }}" -p "${{ secrets.DKR_PASS }}"
+            # Build image
+            ./scripts/tvm_cli/build.sh -c -i "$IMAGE_NAME" -t "$TAG_NAME"
+
+        - name: amd64 cuda image push
+          run: |
+            # Push images to docker hub space
+            docker push $IMAGE_NAME:$TAG_NAME

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,0 +1,82 @@
+name: Docker release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+
+  get-tag:
+
+    if: github.repository_owner == 'autowarefoundation'
+
+    runs-on: ubuntu-latest
+    outputs:
+      tag_ref: ${{ steps.get_tag.outputs.tag_ref }}
+
+    steps:
+      - name: Get tag
+        id: get_tag
+        run: |
+          TAG_REF=${{ github.ref }}
+          TAG_REF=`echo $TAG_REF | cut -c11-`
+          echo ::set-output name=tag_ref::$TAG_REF
+      - name: Echo tag
+        run: echo ${{ steps.get_tag.outputs.tag_ref }}
+
+  build-push-docker:
+      needs: get-tag
+
+      if: github.repository_owner == 'autowarefoundation'
+
+      runs-on: ubuntu-latest
+      env:
+        IMAGE_NAME: autoware/model-zoo-tvm-cli
+        TAG_NAME: ${{ needs.get-tag.outputs.tag_ref }}
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: amd64 image build
+          run: |
+            docker login -u "${{ secrets.DKR_USR }}" -p "${{ secrets.DKR_PASS }}"
+            # Build image
+            ./scripts/tvm_cli/build.sh -i "$IMAGE_NAME" -t "$TAG_NAME"
+
+        - name: amd64 image push
+          run: |
+            # Push images to docker hub space
+            docker tag $IMAGE_NAME:$TAG_NAME $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$TAG_NAME
+            docker push $IMAGE_NAME:latest
+
+  build-push-docker-cuda:
+      needs: get-tag
+
+      if: github.repository_owner == 'autowarefoundation'
+
+      runs-on: ubuntu-latest
+      env:
+        IMAGE_NAME: autoware/model-zoo-tvm-cli
+        TAG_NAME: ${{ needs.get-tag.outputs.tag_ref }}-cuda
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: amd64 image build with cuda
+          run: |
+            docker login -u "${{ secrets.DKR_USR }}" -p "${{ secrets.DKR_PASS }}"
+            # Build image
+            ./scripts/tvm_cli/build.sh -c -i "$IMAGE_NAME" -t "$TAG_NAME"
+
+        - name: amd64 cuda image push
+          run: |
+            # Push images to docker hub space
+            docker tag $IMAGE_NAME:$TAG_NAME $IMAGE_NAME:latest-cuda
+            docker push $IMAGE_NAME:$TAG_NAME
+            docker push $IMAGE_NAME:latest-cuda


### PR DESCRIPTION
Add one CI job for pull request relatives to tvm_cli modification on
scripts or docker, it checks dockerfiles using hadolint and tries to
build images.

Add one CI job triggered by tag, it builds docker images and push it
to the docker hub space, updating the :latest and creating the new
one with the current tag

Add one CI job triggered by push on master when tvm_cli files are
updated, it builds docker images and push it to the docker hub space
using the tag :bleedingedge.

Issue-Id: SCM-1487
Signed-off-by: Luca Fancellu <luca.fancellu@arm.com>
Change-Id: I02eb64c339644847c1433909372af9a7bb534c98