### PR TITLE
Add CI job to test modelzoo contribution on pull requests

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,25 @@
+name: Contribution pull requests validation
+
+on:
+  pull_request:
+
+jobs:
+
+  tvm-cli-validate:
+
+      runs-on: ubuntu-latest
+
+      container:
+        image: autoware/model-zoo-tvm-cli:latest
+
+      steps:
+
+        - name: Checkout
+          uses: actions/checkout@v1
+          with:
+            lfs: true
+
+        - name: tvm_cli test
+          run: |
+            cp -r . /tmp
+            ./scripts/tvm_cli/tvm_cli.py test


### PR DESCRIPTION
Add CI job that runs the tvm_cli.py to test the contribution
on each pull request

Issue-id: SCM-1487
Signed-off-by: Luca Fancellu <luca.fancellu@arm.com>
Change-Id: I660583f9ac2a3322c74b9e8ed1f447da3516617b