### PR TITLE
Enable open source TVM backends

### DIFF
--- a/.github/workflows/docker-pr.yaml
+++ b/.github/workflows/docker-pr.yaml
@@ -24,8 +24,26 @@ jobs:
           hadolint scripts/tvm_cli/Dockerfile.amd64
           hadolint scripts/tvm_cli/Dockerfile.arm64
 
+  setup-docker-arm64:
+      runs-on: ARM64
+
+      steps:
+        - name: Install docker
+          run: |
+            sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+            sudo apt-get update
+            sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+            sudo groupadd docker || true
+            sudo usermod -aG docker ${USER}
+            sudo chmod 666 /var/run/docker.sock
+
+        - name: Prune docker
+          run: docker system prune -a -f
+
   build-docker:
-      needs: dockerfile-lint
+      needs: [dockerfile-lint, setup-docker-arm64]
 
       runs-on: ${{ matrix.os }}
       strategy:
@@ -36,18 +54,6 @@ jobs:
         TAG_NAME: bleedingedge
 
       steps:
-        - name: Install docker
-          if: contains(matrix.os, 'ARM64')
-          run: |
-            sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-            sudo apt-get update
-            sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-            sudo groupadd docker || true
-            sudo usermod -aG docker ${USER}
-            sudo chmod 666 /var/run/docker.sock
-
         - name: Checkout
           uses: actions/checkout@v2
 
@@ -56,7 +62,7 @@ jobs:
             ./scripts/tvm_cli/build.sh -i "$IMAGE_NAME" -t "$TAG_NAME" --ci
 
   build-docker-cuda:
-      needs: dockerfile-lint
+      needs: [dockerfile-lint, setup-docker-arm64]
 
       runs-on: ${{ matrix.os }}
       strategy:
@@ -67,18 +73,6 @@ jobs:
         TAG_NAME: bleedingedge-cuda
 
       steps:
-        - name: Install docker
-          if: contains(matrix.os, 'ARM64')
-          run: |
-            sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-            sudo apt-get update
-            sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-            sudo groupadd docker || true
-            sudo usermod -aG docker ${USER}
-            sudo chmod 666 /var/run/docker.sock
-
         - name: Checkout
           uses: actions/checkout@v2
 

--- a/perception/camera_obstacle_detection/yolo_v2_tiny/tensorflow_fp32_coco/example_pipeline/main.cpp
+++ b/perception/camera_obstacle_detection/yolo_v2_tiny/tensorflow_fp32_coco/example_pipeline/main.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+// Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -112,11 +112,11 @@ int main(int argc, char const *argv[]) {
   int64_t shape_y[] = {1, NETWORK_OUTPUT_WIDTH, NETWORK_OUTPUT_HEIGHT,
                        NETWORK_OUTPUT_DEPTH};
   TVMArrayAlloc(shape_y, sizeof(shape_y) / sizeof(shape_y[0]), TVM_DTYPE_CODE,
-                TVM_DTYPE_BITS, TVM_DTYPE_LANES, TVM_DEVICE_TYPE, TVM_DEVICE_ID,
+                TVM_DTYPE_BITS, TVM_DTYPE_LANES, kDLCPU, 0,
                 &y);
 
   // read input image
-  auto image = cv::imread(IMAGE_FILENAME, CV_LOAD_IMAGE_COLOR);
+  auto image = cv::imread(IMAGE_FILENAME, cv::IMREAD_COLOR);
 
   // Compute the ratio for resizing and size for padding
   double scale_x =
@@ -146,7 +146,7 @@ int main(int argc, char const *argv[]) {
 
   // cv library use BGR as a default color format, the network expects the data
   // in RGB format
-  cv::cvtColor(image_3f, image_3f, CV_BGR2RGB);
+  cv::cvtColor(image_3f, image_3f, cv::COLOR_BGR2RGB);
 
   // copy data from cv::Mat into input DLTensor
   TVMArrayCopyFromBytes(x, image_3f.data,

--- a/scripts/tvm_cli/Dockerfile.amd64
+++ b/scripts/tvm_cli/Dockerfile.amd64
@@ -2,8 +2,14 @@ ARG FROM_ARG
 # hadolint ignore=DL3006
 FROM $FROM_ARG
 
-COPY install_tvm.sh /tmp/install_tvm.sh
-RUN /tmp/install_tvm.sh
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential \
+      libopencv-dev \
+      python3-pip \
+      python3-opencv && \
+    rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=DL3013
 RUN pip3 install --no-cache-dir --upgrade pip && \
@@ -12,15 +18,11 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
       onnx \
       pytest \
       pyyaml \
+      "numpy<1.19.0" \
       "tensorflow==2.3.1"
 
-# hadolint ignore=DL3008
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      build-essential \
-      libopencv-dev \
-      python-opencv && \
-    rm -rf /var/lib/apt/lists/*
+COPY install_tvm.sh /tmp/install_tvm.sh
+RUN /tmp/install_tvm.sh
 
 ENV HOME=/tmp
 WORKDIR /tmp
@@ -30,3 +32,6 @@ COPY templates /tvm_cli/templates
 ENV PATH="/tvm_cli:${PATH}"
 ENTRYPOINT [ "tvm_cli"]
 CMD ["-h"]
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,graphics

--- a/scripts/tvm_cli/Dockerfile.arm64
+++ b/scripts/tvm_cli/Dockerfile.arm64
@@ -7,7 +7,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+        software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=DL3008
@@ -20,11 +21,10 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
         libopencv-dev \
         libprotobuf-dev \
         protobuf-compiler \
-        python-opencv \
-        openjdk-11-jdk-headless \
+        python3-opencv \
         ca-certificates ninja-build git python \
         cmake libopenblas-dev g++ llvm-8 llvm-8-dev clang-9 \
-        python3.6 python3.6-dev python3-setuptools python3-pip antlr4 \
+        python3.8 python3.8-dev python3-setuptools python3-pip antlr4 \
         wget && \
     rm -rf /var/lib/apt/lists/*
 
@@ -69,7 +69,7 @@ RUN git clone --depth 1 -b v2.3.0 https://github.com/tensorflow/tensorflow.git .
     ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
         /tmp/tensorflow_pkg && \
     pip3 install --no-cache-dir \
-        /tmp/tensorflow_pkg/tensorflow-2.3.0-cp36-cp36m-linux_aarch64.whl && \
+        /tmp/tensorflow_pkg/tensorflow-2.3.0-cp38-cp38-linux_aarch64.whl && \
     rm -rf ../tensorflow ../tensorflow_pkg ~/.cache
 
 COPY install_tvm.sh /tmp/install_tvm.sh
@@ -83,3 +83,6 @@ COPY templates /tvm_cli/templates
 ENV PATH="/tvm_cli:${PATH}"
 ENTRYPOINT [ "tvm_cli"]
 CMD ["-h"]
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,graphics

--- a/scripts/tvm_cli/README.md
+++ b/scripts/tvm_cli/README.md
@@ -5,8 +5,10 @@ A command line tool that compiles neural network models using
 
 ## Usage
 
-In all the subsequent commands, if CUDA needs to be enabled, the docker image
-must be run with a flag which exposes the gpu, e.g. [--gpus 0] or [--gpus all].
+In all the subsequent commands, if a GPU needs to be enabled, the docker image
+must be run with the correct flags, e.g. [--gpus 0] or [--gpus all] when running
+an Nvidia GPU with proprietary drivers and
+[--device /dev/dri --group-add video] otherwise.
 
 ```bash
 $ docker run -it --rm -v `pwd`:`pwd` -w `pwd` \
@@ -113,10 +115,7 @@ Successfully built 547afbbfd193
 Successfully tagged autoware/model-zoo-tvm-cli:local
 ```
 
-The previous commands are then used with `:local` instead of `:latest`. If
-Nvidia drivers are installed on the system, CUDA will be enabled for TVM. The
-script also distinguish between an arm64 and an amd64 system to build the
-appropriate docker image.
+The previous commands are then used with `:local` instead of `:latest`.
 
 *Note:* If CUDA is needed, the `build.sh` script must be invoked with the `-c`
 argument. In all the docker commands shown, if CUDA needs to be enabled, the

--- a/scripts/tvm_cli/build.sh
+++ b/scripts/tvm_cli/build.sh
@@ -17,7 +17,7 @@ set -e
 
 IMAGE_NAME="autoware/model-zoo-tvm-cli"
 TAG_NAME="local"
-FROM_ARG="ubuntu:18.04"
+FROM_ARG="ubuntu:20.04"
 TARGET_PLATFORM="arm64"
 if [[ $(uname -a) == *"x86_64"* ]]; then
     TARGET_PLATFORM="amd64"
@@ -86,9 +86,9 @@ while true; do
 done
 
 if [ "$CUDA_ENABLED" == "true" ]; then
-  FROM_ARG="nvidia/cuda-arm64:11.1-devel-ubuntu18.04"
+  FROM_ARG="nvidia/cuda-arm64:11.2.1-devel-ubuntu20.04"
   if [[ "${TARGET_PLATFORM}" == "amd64" ]]; then
-    FROM_ARG="nvidia/cuda:10.1-devel-ubuntu18.04"
+    FROM_ARG="nvidia/cuda:11.0-devel-ubuntu20.04"
   fi
 fi
 

--- a/scripts/tvm_cli/install_tvm.sh
+++ b/scripts/tvm_cli/install_tvm.sh
@@ -29,8 +29,27 @@ apt-get update
 apt-get install -y --no-install-recommends \
         ca-certificates ninja-build git python \
         cmake libopenblas-dev g++ llvm-8 llvm-8-dev clang-9 \
-        python3.6 python3.6-dev python3-setuptools python3-pip antlr4 \
+        python3.8 python3.8-dev python3-setuptools python3-pip antlr4 \
         build-essential
+
+# install opencl
+apt-get install -y --no-install-recommends \
+    mesa-opencl-icd opencl-headers clinfo ocl-icd-opencl-dev
+mkdir -p /etc/OpenCL/vendors
+echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf
+echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+# install vulkan (and opengl to have vulkan work nicely with nvidia)
+apt-get install -y --no-install-recommends \
+    libvulkan1 libvulkan-dev mesa-vulkan-drivers spirv-headers spirv-tools \
+    libglvnd0 libgl1 libglx0 libegl1 libgles2
+mkdir -p /usr/share/vulkan/icd.d
+echo "{ \"file_format_version\" : \"1.0.0\", \"ICD\": { \"library_path\":
+    \"libGLX_nvidia.so.0\" } }" > /usr/share/vulkan/icd.d/nvidia_icd.json
+mkdir -p /usr/share/glvnd/egl_vendor.d
+echo "{ \"file_format_version\" : \"1.0.0\", \"ICD\": { \"library_path\":
+    \"libEGL_nvidia.so.0\" } }" > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
 
 # link clang-9 to be the default clang
 update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
@@ -61,6 +80,8 @@ echo "set(USE_LLVM llvm-config-8)" >> ${TVM_BUILD_CONFIG}
 echo "set(USE_SORT ON)" >> ${TVM_BUILD_CONFIG}
 echo "set(USE_GRAPH_RUNTIME ON)" >> ${TVM_BUILD_CONFIG}
 echo "set(USE_BLAS openblas)" >> ${TVM_BUILD_CONFIG}
+echo "set(USE_OPENCL ON)" >> ${TVM_BUILD_CONFIG}
+echo "set(USE_VULKAN ON)" >> ${TVM_BUILD_CONFIG}
 if [[ -d "/usr/local/cuda" ]]; then
     echo "set(USE_CUDA ON)" >> ${TVM_BUILD_CONFIG}
 fi


### PR DESCRIPTION
Enable using Vulkan and OpenCL (OpenGL is being deprecated in TVM).

Update base image version from Ubuntu 18.04 to 20.04 in order to get
packages new enough to meet Vulkan dependency and solve a bug in MESA
OpenCL. Update Dockerfiles and yolov2 example accordingly.