### PR TITLE
Save artifacts

### DIFF
--- a/.github/workflows/compilation-push-master.yaml
+++ b/.github/workflows/compilation-push-master.yaml
@@ -1,0 +1,44 @@
+name: Compilation push on master
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'scripts/tvm_cli/**'
+      - '**.onnx'
+      - '**.pb'
+
+jobs:
+  compile-push-bucket:
+    if: github.repository_owner == 'autowarefoundation'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ARM64]
+    container:
+      image: autoware/model-zoo-tvm-cli:bleedingedge
+      volumes: /tmp/artifacts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Generate artifacts
+        run: |
+          cp -r . /tmp
+          cd /tmp
+          ./scripts/tvm_cli/tvm_cli.py test
+          tar -czf networks-`uname -m`.tar.gz -C /tmp/neural_networks/`uname -m`/ .
+          mv networks-`uname -m`.tar.gz /tmp/artifacts
+
+      - name: Save artifacts
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks
+          env:
+            AWS_S3_BUCKET: autoware-modelzoo
+            AWS_ACCESS_KEY_ID: ${{ secrets.MODELZOO_S3_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.MODELZOO_S3_KEY }}
+            SOURCE_DIR: '/tmp/artifacts'

--- a/scripts/tvm_cli/README.md
+++ b/scripts/tvm_cli/README.md
@@ -41,6 +41,8 @@ The output will consist of these file:
 - `inference_engine_tvm_config.hpp` contains declaration of a structure with
   configuration for the TVM runtime C++ API.
 
+The target device can be set with the `--target` parameter.
+
 ### Tuning a model in the model zoo
 
 ```bash

--- a/scripts/tvm_cli/templates/inference_engine_tvm_config.hpp.jinja2
+++ b/scripts/tvm_cli/templates/inference_engine_tvm_config.hpp.jinja2
@@ -23,6 +23,9 @@ namespace {{ ns }}
 {%- endfor %}
 
 tvm_utility::pipeline::InferenceEngineTVMConfig config {
+  .network_name = "{{ network_name }}",
+  .network_backend = "{{ network_backend }}",
+
   .network_module_path = "{{ network_module_path }}",
   .network_graph_path = "{{ network_graph_path }}",
   .network_params_path = "{{ network_params_path }}",

--- a/scripts/tvm_cli/tvm_cli.py
+++ b/scripts/tvm_cli/tvm_cli.py
@@ -28,6 +28,12 @@ OUTPUT_NETWORK_GRAPH_FILENAME = "deploy_graph.json"
 OUTPUT_NETWORK_PARAM_FILENAME = "deploy_param.params"
 OUTPUT_CONFIG_FILENAME = "inference_engine_tvm_config.hpp"
 
+TARGETS_DEVICES = {
+    'llvm':'kDLCPU',
+    'cuda':'kDLGPU',
+    'opencl':'kDLOpenCL',
+    'vulkan':'kDLVulkan',
+}
 GPU_TARGETS = ['cuda', 'opencl', 'vulkan']
 
 # Utility function: definition.yaml file processing
@@ -117,7 +123,7 @@ def compilation_preprocess(args):
     info = {}
 
     info['lanes'] = args.lanes
-    info['device_type'] = args.device_type
+    info['device_type'] = TARGETS_DEVICES[args.target]
     info['device_id'] = args.device_id
     info['target'] = args.target
     info['cross_compile'] = args.cross_compile
@@ -409,7 +415,8 @@ if __name__ == '__main__':
     def compile():
         parser = argparse.ArgumentParser(
             description='Compile a model using TVM',
-            usage='''tvm_cli compile [<args>]''')
+            usage='''tvm_cli compile [<args>]''',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         requiredNamed = parser.add_argument_group('required arguments')
         requiredNamed.add_argument('--config',
                                    help='Path to .yaml config file (input)',
@@ -419,33 +426,28 @@ if __name__ == '__main__':
                                         'network graph and network parameters '
                                         'will be stored',
                                    required=True)
-        parser.add_argument('--device_type',
-                            help='User-specified device type',
-                            choices=['kDLCPU', 'kDLGPU', 'kDLCPUPinned',
-                                     'kDLOpenCL', 'kDLVulkan', 'kDLMetal',
-                                     'kDLVPI', 'kDLROCM', 'kDLExtDev'],
-                            default='kDLCPU')
+        targets = list(TARGETS_DEVICES)
+        parser.add_argument('--target',
+                            help='Compilation target',
+                            choices=targets,
+                            default=targets[0])
         parser.add_argument('--device_id',
-                            help='User-specified device ID',
+                            help='Device ID',
                             type=int,
                             default=0)
         parser.add_argument('--lanes',
-                            help='Number of lanes, default value is 1',
+                            help='Number of lanes',
                             type=int,
                             default=1)
-        parser.add_argument('--target',
-                            help='Set the compilation target',
-                            choices=['llvm'] + GPU_TARGETS,
-                            default='llvm')
         parser.add_argument('--cross_compile',
-                            help='Set to cross compile for ArmV8a with NEON',
+                            help='Cross compile for ArmV8a with NEON',
                             action='store_true',
                             default=False)
         parser.add_argument('--autotvm_log',
                             help='Path to an autotvm .log file, can speed up '
                                  'inference')
         parser.add_argument('--autoware_version',
-                            help='Set the targeted Autoware version',
+                            help='Targeted Autoware version',
                             choices=['ai', 'auto'],
                             default='auto')
 

--- a/scripts/tvm_cli/tvm_cli.py
+++ b/scripts/tvm_cli/tvm_cli.py
@@ -149,8 +149,10 @@ def compilation_preprocess(args):
     namespaces = model_dir.split(path.sep)
     if len(namespaces) < 4:
         info['namespace'] = model_dir
+        info['network_name'] = model_dir
     else:
         info['namespace'] = path.sep.join(namespaces[-4:])
+        info['network_name'] = namespaces[-2]
 
     return info
 
@@ -223,6 +225,8 @@ def generate_config_file(info):
         fh.write(template.render(
             namespace = info['namespace'],
             header_extension = info['header_extension'],
+            network_name = info['network_name'],
+            network_backend = info['target'],
             network_module_path = path.join('.',
                                             OUTPUT_NETWORK_MODULE_FILENAME),
             network_graph_path = path.join('.',

--- a/scripts/tvm_cli/validation/tvm_cli_test.py
+++ b/scripts/tvm_cli/validation/tvm_cli_test.py
@@ -13,42 +13,18 @@ import pytest
 from glob import glob
 from os import path
 import tempfile
-import platform
+from pathlib import Path
 
 MOUNT_PATH = '/tmp'
+BACKENDS = ['llvm', 'vulkan']
 
-# Create a list containing the paths to all the .yaml files found in the
-# mounted folder
-definition_files = glob(MOUNT_PATH + '/**/definition.yaml', recursive=True)
-
-# Create a list containing only those files which have enable_testing: true
-files_to_test = []
-for definition_file in definition_files:
-    with open(definition_file, 'r') as yaml_file:
-        if yaml.safe_load(yaml_file)['enable_testing']:
-            files_to_test.append(definition_file)
-
-# Determine the target platforms based on the native architecture.
-targets = ['native']
-if platform.machine() != 'aarch64':
-    targets.append('aarch64-cross-compilation')
-
-# Parameterizing the test_tvm_cli function, we generate separate tests for
-# every .yaml file: one for native compilation and one for aarch64 cross
-# compilation when necessary.
-@pytest.mark.parametrize('target', targets)
-@pytest.mark.parametrize('definition_file', files_to_test)
-def test_tvm_cli(target, definition_file):
-    # Create a temporary directory for every model
-    output_folder = tempfile.mkdtemp()
-
-    # Execute tvm_cli and check the return code
+# Execute tvm_cli and check the return code
+def run_tvm_cli(config_path, output_folder, extra_run_args):
     run_arg = [path.join(MOUNT_PATH, "./scripts/tvm_cli/tvm_cli.py"),
                'compile',
-               '--config', definition_file,
+               '--config', config_path,
                '--output_path', output_folder]
-    if target == 'aarch64-cross-compilation':
-        run_arg.append('--cross_compile')
+    run_arg += extra_run_args
     proc = subprocess.run(run_arg)
     assert proc.returncode == 0
 
@@ -58,6 +34,48 @@ def test_tvm_cli(target, definition_file):
     assert os.path.exists(os.path.join(output_folder, 'deploy_param.params'))
     assert os.path.exists(os.path.join(output_folder,
                                        'inference_engine_tvm_config.hpp'))
+
+# Create a list containing the paths to all the .yaml files found in the
+# mounted folder
+definition_files = glob(MOUNT_PATH + '/**/definition.yaml', recursive=True)
+
+# Create a dictionary containing the network names associated to their path, for
+# the files which have enable_testing: true
+networks_to_compile = {}
+for definition_file in definition_files:
+    with open(definition_file, 'r') as yaml_file:
+        yaml_dict = yaml.safe_load(yaml_file)
+        if yaml_dict['enable_testing']:
+            network_name = definition_file.split(path.sep)[-3]
+            networks_to_compile[network_name] = definition_file
+
+root_folder = path.join(MOUNT_PATH, 'neural_networks', os.uname().machine)
+
+# Parameterizing the test_tvm_cli function, we generate separate tests for
+# every .yaml file: one for each target backend.
+@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize('network_name', list(networks_to_compile))
+def test_tvm_cli(backend, network_name):
+    # Create a directory for every model
+    output_folder = path.join(root_folder, backend, network_name)
+    Path(output_folder).mkdir(parents=True, exist_ok=True)
+
+    config_path = networks_to_compile[network_name]
+    extra_run_args = ['--target', backend]
+    run_tvm_cli(config_path, output_folder, extra_run_args)
+
+# Parameterizing the test_tvm_cli function, we generate separate tests for
+# every .yaml file.
+@pytest.mark.skipif(os.uname().machine == 'aarch64',
+                    reason='would cross-compile to itself')
+@pytest.mark.parametrize('network_name', list(networks_to_compile))
+def test_tvm_cli_cross_compile(network_name):
+    # Create a directory for every model
+    output_folder = tempfile.mkdtemp()
+
+    config_path = networks_to_compile[network_name]
+    extra_run_args = ['--cross_compile']
+    run_tvm_cli(config_path, output_folder, extra_run_args)
 
     # Delete the output folder
     shutil.rmtree(output_folder)


### PR DESCRIPTION
Cleanup tvm_cli compile arguments.

Export new `network_name` and `network_backend` fields in the template header, breaking compatibility with modelzoo v1 tag.

Save artifacts during validation tests (except for cross-compilation).

Sync those artifacts to S3 bucket as part of the CI.