### PR TITLE
[#53][CI] Add libtvm_runtime.so to docker image

### DIFF
--- a/scripts/tvm_cli/Dockerfile.amd64
+++ b/scripts/tvm_cli/Dockerfile.amd64
@@ -30,6 +30,7 @@ COPY tvm_cli.py /tvm_cli/tvm_cli
 COPY templates /tvm_cli/templates
 # hadolint ignore=DL3044
 ENV PATH="/tvm_cli:${PATH}"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 ENTRYPOINT [ "tvm_cli"]
 CMD ["-h"]
 

--- a/scripts/tvm_cli/Dockerfile.arm64
+++ b/scripts/tvm_cli/Dockerfile.arm64
@@ -85,6 +85,7 @@ RUN true
 COPY templates /tvm_cli/templates
 # hadolint ignore=DL3044
 ENV PATH="/tvm_cli:${PATH}"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 ENTRYPOINT [ "tvm_cli"]
 CMD ["-h"]
 


### PR DESCRIPTION
Solve a bug where libtvm_runtime.so couldn't be
loaded at runtime when running a pipeline

Issue-Id: SCM-3334
Signed-off-by: Luca Foschiani <luca.foschiani@arm.com>
Change-Id: Ia92103b988e579b303c917b5fda5189504a40c59